### PR TITLE
[R4R] Throw error in checkTxHash if result contains tendermint error

### DIFF
--- a/example/cdp.js
+++ b/example/cdp.js
@@ -54,10 +54,9 @@ var main = async () => {
     const txHashCDP = await kavaClient.createCDP(principal, collateral);
     console.log("Create CDP tx hash (Kava): ".concat(txHashCDP));
 
-    // Get account balance
-    account = await kavaClient.getAccount(kavaClient.wallet.address, 5000);
-    console.log("Address:", _.get(account, "value.address"));
-    console.log("Balances:", _.get(account, "value.coins"), "\n");
+    // Check the claim tx hash
+    const txRes = await kavaClient.checkTxHash(txHashCDP, 15000);
+    console.log('\nTx result:', txRes);
 };
 
 main()

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -334,11 +334,25 @@ class KavaClient {
   async checkTxHash(txHash, timeout = 10000) {
     const path = api.txs + '/' + txHash;
     let res;
+
+    // Query the chain for a transaction with this hash
     try {
       res = await tx.getTx(path, this.baseURI, timeout);
     } catch (e) {
       throw new Error(`tx not found: ${e}`);
     }
+
+    // If the transaction is found, check that it was accepted by the chain
+    try {
+      if (_.get(res, 'data.code')) {
+        throw new Error(
+          `tx not accepted by chain: "${_.get(res, 'data.raw_log')}"`
+        );
+      }
+     } catch (e) {
+       console.log("\n" + e)
+     }
+    
     return res.data;
   }
   


### PR DESCRIPTION
Does this implement the requested feature? 

Should execution stop upon a tendermint error? I think it should log the error but execution should continue (as implemented).