### PR TITLE
Expand Kava client methods

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -31,6 +31,8 @@ const api = {
   getAssetSupplies: 'bep3/supplies',
   getCDP: 'cdp/cdps/cdp',
   getCDPs: '/cdp/cdps/denom',
+  getCDPsRatio: '/cdp/cdps/ratio',
+  getDeposits: '/cdp/cdps/deposits',
   getAuction: '/auction/auctions',
   getAuctions: '/auction/auctions',
   getClaims: '/incentive/claims',
@@ -514,6 +516,36 @@ class KavaClient {
    */
   async getCDPs(collateralDenom, timeout = 2000) {
     const path = api.getCDPs + '/' + collateralDenom;
+    const res = await tx.getTx(path, this.baseURI, timeout);
+    if (res && res.data) {
+      return res.data.result;
+    }
+  }
+
+  /**
+   * Get all CDPs for an asset that are under the collateralization ratio specified
+   * @param {String} collateralDenom denom of the CDP's collateral asset
+   * @param {String} ratio upper collateralization ratio limit of the query
+   * @param {Number} timeout request is attempted every 1000 milliseconds until millisecond timeout is reached
+   * @return {Promise}
+   */
+  async getCDPsByRatio(collateralDenom, ratio, timeout = 2000) {
+    const path = api.getCDPsRatio + '/' + collateralDenom + '/' + ratio;
+    const res = await tx.getTx(path, this.baseURI, timeout);
+    if (res && res.data) {
+      return res.data.result;
+    }
+  }
+
+  /**
+   * Get all deposits for the CDP with the specified owner and collateral asset
+   * @param {String} owner the address that owns the CDP
+   * @param {String} collateralDenom denom of the CDP's collateral asset
+   * @param {Number} timeout request is attempted every 1000 milliseconds until millisecond timeout is reached
+   * @return {Promise}
+   */
+  async getDeposits(owner, collateralDenom, timeout = 2000) {
+    const path = api.getDeposits + '/' + owner + '/' + collateralDenom;
     const res = await tx.getTx(path, this.baseURI, timeout);
     if (res && res.data) {
       return res.data.result;

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -445,12 +445,13 @@ class KavaClient {
   }
 
   /**
-   * Get all active auctions
+   * Get auctions, filterable by args.
    * @param {Number} timeout request is attempted every 1000 milliseconds until millisecond timeout is reached
+   * @param {Object} args request args as JSON. Example: {type: "collateral", denom: "btc"}
    * @return {Promise}
    */
-  async getAuctions(timeout = 2000) {
-    const res = await tx.getTx(api.getAuctions, this.baseURI, timeout);
+  async getAuctions(timeout = 2000, args = {}) {
+    const res = await tx.getTx(api.getAuctions, this.baseURI, timeout, args);
     if (res && res.data) {
       return res.data.result;
     }
@@ -648,14 +649,14 @@ class KavaClient {
     }
   }
 
-  // TODO: swap filtering
   /**
-   * Get all swaps
+   * Get swaps, filterable by args.
+   * @param {Object} args request args as JSON. Example: {status: "Open", direction: "Incoming"}
    * @param {Number} timeout request is attempted every 1000 milliseconds until millisecond timeout is reached
    * @return {Promise}
    */
-  async getSwaps(timeout = 2000) {
-    const res = await tx.getTx(api.getSwaps, this.baseURI, timeout);
+  async getSwaps(timeout = 2000, args = {}) {
+    const res = await tx.getTx(api.getSwaps, this.baseURI, timeout, args);
     if (res && res.data) {
       return res.data.result;
     }

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -7,16 +7,17 @@ const defaultPrefix = 'kava';
 const defaultDerivationPath = "m/44'/459'/0'/0/0";
 
 const api = {
+  txs: '/txs',
   nodeInfo: '/node_info',
+  getBlock: '/blocks',
   getLatestBlock: '/blocks/latest',
-  getBlock: '/blocks/',
   getLatestValidatorSet: '/validatorsets/latest',
   getValidatorSet: '/validatorsets/',
-  txs: '/txs',
   getParamsPricefeed: '/pricefeed/parameters',
   getParamsAuction: '/auction/parameters',
   getParamsCDP: '/cdp/parameters',
   getParamsBEP3: '/bep3/parameters',
+  getParamsIncentive: '/incentive/parameters',
   getAccount: '/auth/accounts',
   getBalances: '/bank/balances',
   getSupply: '/supply/total',
@@ -32,6 +33,9 @@ const api = {
   getCDPs: '/cdp/cdps/denom',
   getAuction: '/auction/auctions', // TODO:
   getAuctions: '/auction/auctions',
+  getClaims: '/incentive/claims',
+  getRewardPeriods: '/incentive/rewardperiods',
+  getClaimPeriods: '/incentive/claimperiods',
 };
 
 /**
@@ -751,6 +755,78 @@ class KavaClient {
     const signedTx = tx.signTx(rawTx, signInfo, this.wallet);
     return await tx.broadcastTx(signedTx, this.baseURI, this.broadcastMode);
   }
+
+  /***************************************************
+   *                    Incentive
+   ***************************************************/
+  /**
+   * Get the params of the incentive module
+   * @param {Number} timeout request is attempted every 1000 milliseconds until millisecond timeout is reached
+   * @return {Promise}
+   */
+  async getParamsIncentive(timeout = 2000) {
+    const res = await tx.getTx(api.getParamsIncentive, this.baseURI, timeout);
+    if (res && res.data) {
+      return res.data.result;
+    }
+  }
+
+  /**
+   * Get the params of the incentive module
+   * @param {String} address the address to be queried
+   * @param {String} denom name of the asset to be queried
+   * @param {Number} timeout request is attempted every 1000 milliseconds until millisecond timeout is reached
+   * @return {Promise}
+   */
+  async getClaims(address, denom, timeout = 2000) {
+    const path = api.getClaims + '/' + address + '/' + denom;
+    const res = await tx.getTx(api.getClaims, this.baseURI, timeout);
+    if (res && res.data) {
+      return res.data.result;
+    }
+  }
+
+  /**
+   * Get all incentive reward periods
+   * @param {Number} timeout request is attempted every 1000 milliseconds until millisecond timeout is reached
+   * @return {Promise}
+   */
+  async getRewardPeriods(timeout = 2000) {
+    const res = await tx.getTx(api.getRewardPeriods, this.baseURI, timeout);
+    if (res && res.data) {
+      return res.data.result;
+    }
+  }
+
+  /**
+   * Get all incentive claim periods
+   * @param {Number} timeout request is attempted every 1000 milliseconds until millisecond timeout is reached
+   * @return {Promise}
+   */
+  async getClaimPeriods(timeout = 2000) {
+    const res = await tx.getTx(api.getClaimPeriods, this.baseURI, timeout);
+    if (res && res.data) {
+      return res.data.result;
+    }
+  }
+
+  /**
+   * Claim a reward by denom
+   * @param {String} denom the name of the asset to be claimed
+   * @param {String} sequence optional account sequence
+   * @return {Promise}
+   */
+  async claimReward(denom, sequence = null) {
+    const msgClaimReward = msg.newMsgClaimReward(
+      this.wallet.address,
+      denom
+    );
+    const rawTx = msg.newStdTx([msgClaimReward]);
+    const signInfo = await this.prepareSignInfo(sequence);
+    const signedTx = tx.signTx(rawTx, signInfo, this.wallet);
+    return await tx.broadcastTx(signedTx, this.baseURI, this.broadcastMode);
+  }
+
 }
 
 module.exports.KavaClient = KavaClient;

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -19,7 +19,7 @@ const api = {
   getParamsBEP3: '/bep3/parameters',
   getParamsIncentive: '/incentive/parameters',
   getAccount: '/auth/accounts',
-  getBalances: '/bank/balances',
+  // getBalances: '/bank/balances', TODO: Will be supported soon.
   getSupply: '/supply/total',
   getMarkets: 'pricefeed/markets',
   getOracles: 'pricefeed/oracles',
@@ -270,19 +270,19 @@ class KavaClient {
     }
   }
 
-  /**
-   * Get an account's balances
-   * @param {String} address account to query
-   * @param {Number} timeout request is attempted every 1000 milliseconds until millisecond timeout is reached
-   * @return {Promise}
-   */
-  async getBalances(address, timeout = 2000) {
-    const path = api.getBalances + '/' + address;
-    const res = await tx.getTx(path, this.baseURI, timeout);
-    if (res && res.data) {
-      return res.data.result;
-    }
-  }
+  // /**  TODO: Will be supported soon.
+  //  * Get an account's balances
+  //  * @param {String} address account to query
+  //  * @param {Number} timeout request is attempted every 1000 milliseconds until millisecond timeout is reached
+  //  * @return {Promise}
+  //  */
+  // async getBalances(address, timeout = 2000) {
+  //   const path = api.getBalances + '/' + address;
+  //   const res = await tx.getTx(path, this.baseURI, timeout);
+  //   if (res && res.data) {
+  //     return res.data.result;
+  //   }
+  // }
 
   /**
    * Get the total supply of coins on the chain

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -20,6 +20,8 @@ const api = {
   getAccount: '/auth/accounts',
   getBalances: '/bank/balances',
   getSupply: '/supply/total',
+  getMarkets: 'pricefeed/markets',
+  getOracles: 'pricefeed/oracles',
   getPrice: '/pricefeed/price',
   getRawPrices: '/pricefeed/rawprices',
   getSwap: 'bep3/swap',
@@ -353,6 +355,32 @@ class KavaClient {
    */
   async getRawPrices(market, timeout = 2000) {
     const path = api.getRawPrices + '/' + market;
+    const res = await tx.getTx(path, this.baseURI, timeout);
+    if (res && res.data) {
+      return res.data.result;
+    }
+  }
+
+  /**
+   * Get all active markets
+   * @param {Number} timeout request is attempted every 1000 milliseconds until millisecond timeout is reached
+   * @return {Promise}
+   */
+  async getMarkets(timeout = 2000) {
+    const res = await tx.getTx(api.getMarkets, this.baseURI, timeout);
+    if (res && res.data) {
+      return res.data.result;
+    }
+  }
+
+  /**
+   * Get all active oracles for an asset
+   * @param {String} denom asset's name
+   * @param {Number} timeout request is attempted every 1000 milliseconds until millisecond timeout is reached
+   * @return {Promise}
+   */
+  async getOracles(denom, timeout = 2000) {
+    const path = api.getOracles + '/' + denom;
     const res = await tx.getTx(path, this.baseURI, timeout);
     if (res && res.data) {
       return res.data.result;

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -9,19 +9,26 @@ const defaultDerivationPath = "m/44'/459'/0'/0/0";
 const api = {
   nodeInfo: '/node_info',
   getLatestBlock: '/blocks/latest',
+  getBlock: '/blocks/',
+  getLatestValidatorSet: '/validatorsets/latest',
+  getValidatorSet: '/validatorsets/',
   txs: '/txs',
   getParamsPricefeed: '/pricefeed/parameters',
   getParamsAuction: '/auction/parameters',
   getParamsCDP: '/cdp/parameters',
   getParamsBEP3: '/bep3/parameters',
   getAccount: '/auth/accounts',
+  getBalances: '/bank/balances',
+  getSupply: '/supply/total',
   getPrice: '/pricefeed/price',
   getRawPrices: '/pricefeed/rawprices',
   getSwap: 'bep3/swap',
   getSwaps: '/bep3/swaps',
+  getAssetSupply: 'bep3/supply',
+  getAssetSupplies: 'bep3/supplies',
   getCDP: 'cdp/cdps/cdp',
   getCDPs: '/cdp/cdps/denom',
-  getAuction: '/auction/auctions',
+  getAuction: '/auction/auctions', // TODO:
   getAuctions: '/auction/auctions',
 };
 
@@ -155,7 +162,7 @@ class KavaClient {
    *                   Tendermint
    ***************************************************/
   /**
-   * Get information about an account
+   * Get the latest block
    * @param {Number} timeout request is attempted every 1000 milliseconds until millisecond timeout is reached
    * @return {Promise}
    */
@@ -164,6 +171,46 @@ class KavaClient {
       if (res && res.data) {
         return res.data;
       }
+  }
+
+  /**
+   * Get a block at a specific height
+   * @param {Number} height the block's height
+   * @param {Number} timeout request is attempted every 1000 milliseconds until millisecond timeout is reached
+   * @return {Promise}
+   */
+  async getBlock(height, timeout = 2000) {
+    const path = api.getBlock + '/' + String(height);
+    const res = await tx.getTx(path, this.baseURI, timeout);
+    if (res && res.data) {
+      return res.data;
+    }
+  }
+
+  /**
+   * Get the latest set of validators
+   * @param {Number} timeout request is attempted every 1000 milliseconds until millisecond timeout is reached
+   * @return {Promise}
+   */
+  async getLatestValidatorSet(timeout = 2000) {
+    const res = await tx.getTx(api.getLatestValidatorSet, this.baseURI, timeout);
+    if (res && res.data) {
+      return res.data;
+    }
+  }
+
+  /**
+   * Get a set of validators at a specific block height
+   * @param {Number} height the block's height
+   * @param {Number} timeout request is attempted every 1000 milliseconds until millisecond timeout is reached
+   * @return {Promise}
+   */
+  async getValidatorSet(height, timeout = 2000) {
+    const path = api.getValidatorSet + '/' + String(height);
+    const res = await tx.getTx(path, this.baseURI, timeout);
+    if (res && res.data) {
+      return res.data;
+    }
   }
 
   /**
@@ -208,6 +255,46 @@ class KavaClient {
    */
   async getAccount(address, timeout = 2000) {
     const path = api.getAccount + '/' + address;
+    const res = await tx.getTx(path, this.baseURI, timeout);
+    if (res && res.data) {
+      return res.data.result;
+    }
+  }
+
+  /**
+   * Get an account's balances
+   * @param {String} address account to query
+   * @param {Number} timeout request is attempted every 1000 milliseconds until millisecond timeout is reached
+   * @return {Promise}
+   */
+  async getBalances(address, timeout = 2000) {
+    const path = api.getBalances + '/' + address;
+    const res = await tx.getTx(path, this.baseURI, timeout);
+    if (res && res.data) {
+      return res.data.result;
+    }
+  }
+
+  /**
+   * Get the total supply of coins on the chain
+   * @param {Number} timeout request is attempted every 1000 milliseconds until millisecond timeout is reached
+   * @return {Promise}
+   */
+  async getSupply(timeout = 2000) {
+    const res = await tx.getTx(api.getSupply, this.baseURI, timeout);
+    if (res && res.data) {
+      return res.data.result;
+    }
+  }
+
+  /**
+   * Get the total supply of coins on the chain
+   * @param {String} denom the name of the asset whose total supply will be queried
+   * @param {Number} timeout request is attempted every 1000 milliseconds until millisecond timeout is reached
+   * @return {Promise}
+   */
+  async getSupplyOf(denom, timeout = 2000) {
+    const path = api.getSupply + '/' + denom;
     const res = await tx.getTx(path, this.baseURI, timeout);
     if (res && res.data) {
       return res.data.result;
@@ -526,6 +613,7 @@ class KavaClient {
     }
   }
 
+  // TODO: swap filtering
   /**
    * Get all swaps
    * @param {Number} timeout request is attempted every 1000 milliseconds until millisecond timeout is reached
@@ -533,6 +621,32 @@ class KavaClient {
    */
   async getSwaps(timeout = 2000) {
     const res = await tx.getTx(api.getSwaps, this.baseURI, timeout);
+    if (res && res.data) {
+      return res.data.result;
+    }
+  }
+
+  /**
+   * Get an asset's total supply by its denom
+   * @param {String} assetDenom the asset's denom
+   * @param {Number} timeout request is attempted every 1000 milliseconds until millisecond timeout is reached
+   * @return {Promise}
+   */
+  async getAssetSupply(assetDenom, timeout = 2000) {
+    const path = api.getAssetSupply + '/' + assetDenom;
+    const res = await tx.getTx(path, this.baseURI, timeout);
+    if (res && res.data) {
+      return res.data.result;
+    }
+  }
+
+  /**
+   * Get all supplies
+   * @param {Number} timeout request is attempted every 1000 milliseconds until millisecond timeout is reached
+   * @return {Promise}
+   */
+  async getAssetSupplies(timeout = 2000) {
+    const res = await tx.getTx(api.getAssetSupplies, this.baseURI, timeout);
     if (res && res.data) {
       return res.data.result;
     }
@@ -608,7 +722,7 @@ class KavaClient {
     const signInfo = await this.prepareSignInfo(sequence);
     const signedTx = tx.signTx(rawTx, signInfo, this.wallet);
     return await tx.broadcastTx(signedTx, this.baseURI, this.broadcastMode);
-  }  
+  }
 }
 
 module.exports.KavaClient = KavaClient;

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -8,6 +8,7 @@ const defaultDerivationPath = "m/44'/459'/0'/0/0";
 
 const api = {
   nodeInfo: '/node_info',
+  getLatestBlock: '/blocks/latest',
   txs: '/txs',
   getParamsPricefeed: '/pricefeed/parameters',
   getParamsAuction: '/auction/parameters',
@@ -153,6 +154,18 @@ class KavaClient {
   /***************************************************
    *                 GET tx methods
    ***************************************************/
+
+  /**
+   * Get information about an account
+   * @param {Number} timeout request is attempted every 1000 milliseconds until millisecond timeout is reached
+   * @return {Promise}
+   */
+  async getLatestBlock(timeout = 2000) {
+      const res = await tx.getTx(api.getLatestBlock, this.baseURI, timeout);
+      if (res && res.data) {
+        return res.data;
+      }
+  }
 
   /**
    * Get information about an account

--- a/src/msg/index.js
+++ b/src/msg/index.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 
-const defaultFee = { amount: [], gas: '200000' };
+const defaultFee = { amount: [], gas: '250000' };
 
 // newStdTx creates a new StdTx from some messages, with default values for fees, memo and sigs
 function newStdTx(msgs, fee = defaultFee, memo = '', signatures = null) {
@@ -175,6 +175,27 @@ function newMsgClaimReward(sender, denom) {
   };
 }
 
+function newMsgSubmitProposal(proposal, proposer, committeeID) {
+  return {
+    type: 'kava/MsgSubmitProposal',
+    value: {
+      pub_proposal: proposal,
+      proposer: proposer,
+      committee_id: String(committeeID),
+    },
+  };
+}
+
+function newMsgVote(proposalID, voter) {
+  return {
+    type: 'kava/MsgVote',
+    value: {
+      proposal_id: String(proposalID),
+      voter: voter,
+    },
+  };
+}
+
 module.exports.msg = {
   newStdTx,
   newMsgSend,
@@ -189,4 +210,6 @@ module.exports.msg = {
   newMsgClaimAtomicSwap,
   newMsgRefundAtomicSwap,
   newMsgClaimReward,
+  newMsgSubmitProposal,
+  newMsgVote,
 };

--- a/src/msg/index.js
+++ b/src/msg/index.js
@@ -165,6 +165,16 @@ function newMsgRefundAtomicSwap(sender, swapID) {
   };
 }
 
+function newMsgClaimReward(sender, denom) {
+  return {
+    type: 'incentive/MsgClaimReward',
+    value: {
+      sender: sender,
+      denom: denom,
+    },
+  };
+}
+
 module.exports.msg = {
   newStdTx,
   newMsgSend,
@@ -178,4 +188,5 @@ module.exports.msg = {
   newMsgCreateAtomicSwap,
   newMsgClaimAtomicSwap,
   newMsgRefundAtomicSwap,
+  newMsgClaimReward,
 };

--- a/src/tx/index.js
+++ b/src/tx/index.js
@@ -9,6 +9,43 @@ const api = {
 };
 
 /**
+ * Sends an HTTP GET request to Kava
+ * @param {String} path the request's url extension
+ * @param {String} base the request's base url
+ * @return {Promise}
+ */
+async function getTx(path, base, timeout = 5000, args = {}) {
+  const requestUrl = new URL(path, base).toString()
+
+  try {
+    return await retry(
+      axios.get,
+      axios,
+      [applyRequestArgs(requestUrl, args)],
+      Math.floor(timeout / 1000),
+      1000,
+      false
+    );
+  } catch (err) {
+    throw new Error(err);
+  }
+}
+
+/**
+ * Apply args to an HTTP GET request's url
+ * @param {String} url the request's url (base + path extension)
+ * @param {String} args the request's http arguments in JSON e.g. {status: 'Open'}
+ * @return {String}
+ */
+function applyRequestArgs(url, args = {}) {
+  const search = []
+  for (let k in args) {
+    search.push(`${k}=${args[k]}`)
+  }
+  return `${url}?${search.join("&")}`
+}
+
+/**
  * Retries the given function until it succeeds given a number of retries and an interval between them. They are set
  * by default to retry 5 times with 1sec in between. There's also a flag for exponential back-off.
  * source (with minor edits): https://gitlab.com/snippets/1775781
@@ -45,27 +82,6 @@ async function retry(
     } else
       throw new Error(`Max retries reached:
     error: ${error}`);
-  }
-}
-
-/**
- * Sends an HTTP GET request to Kava
- * @param {String} path the request's url extension
- * @param {String} base the request's base url
- * @return {Promise}
- */
-async function getTx(path, base, timeout = 5000) {
-  try {
-    return await retry(
-      axios.get,
-      axios,
-      [new URL(path, base).toString()],
-      Math.floor(timeout / 1000),
-      1000,
-      false
-    );
-  } catch (err) {
-    throw new Error(err);
   }
 }
 


### PR DESCRIPTION
- [x] basic tendermint, cosmos-sdk queries (closes https://github.com/Kava-Labs/javascript-sdk/issues/3)
- [x] all remaining pricefeed, auction, cdp, and bep3 queries
- [x] incentive queries and txs
- [x] committee queries and txs
- [x] implement args for http get requests (just getSwaps, getAuctions for now)

Follow on PR will update the examples and documentation. Not all methods have been tested, I'll do that as part of the next PR.
