### PR TITLE
fix: return empty sign meta for new account

### DIFF
--- a/src/tx/index.js
+++ b/src/tx/index.js
@@ -97,13 +97,15 @@ async function loadMetaData(address, base, timeout = 2000) {
   const res = await getTx(path, base, timeout);
   accNum = _.get(res, 'data.result.value.account_number');
   seqNum = _.get(res, 'data.result.value.sequence');
-  if (!(accNum || seqNum)) {
-    throw new Error(
-      'account number or sequence number from rest server are undefined'
-    );
+  let signMetaData
+  if ((typeof accNum === 'undefined' || typeof seqNum === 'undefined')) {
+    signMetaData = {
+      account_number: '0',
+      sequence: '0',
+    };
   }
 
-  const signMetaData = {
+  signMetaData = {
     account_number: accNum,
     sequence: seqNum,
   };

--- a/src/tx/index.js
+++ b/src/tx/index.js
@@ -99,18 +99,17 @@ async function loadMetaData(address, base, timeout = 2000) {
   seqNum = _.get(res, 'data.result.value.sequence');
   let signMetaData
   if ((typeof accNum === 'undefined' || typeof seqNum === 'undefined')) {
-    signMetaData = {
-      account_number: '0',
-      sequence: '0',
+     signMetaData = {
+      account_number: typeof accNum === 'undefined' ? '0' : accNum,
+      sequence: typeof seqNum === 'undefined' ? '0' : seqNum,
     };
+    return signMetaData
   }
 
-  signMetaData = {
+  return {
     account_number: accNum,
     sequence: seqNum,
   };
-
-  return signMetaData;
 }
 
 /**


### PR DESCRIPTION
Setting up testnets has surfaced the following issue:

If an account holds coins, but has not sent a transaction, the oracle bot (in kava-tools) fails to load the account metadeta because the account sequence is 'falsey'. This fix attempts to solve this issue by returning an empty sign metadata object when it is undefined from the server. Will test locally with the oracle bot to see if there are further issues. 