### PR TITLE
kava-4 mainnet updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,29 +10,46 @@ The Kava JavaScript SDK allows browsers and node.js clients to interact with Kav
 
 ## Installation
 
-Install the package via npm.
+Install the package via npm. The current version compatible with kava-4 mainnet is 3.0.0-beta.2.
 
 ```bash
-npm install @kava-labs/javascript-sdk
+npm install @kava-labs/javascript-sdk@3.0.0-beta.2
 ```
 
 ## Network Information
 
 ### Mainnet
 
-- Chain ID: kava-3
-- REST API endpoint: https://kava3.data.kava.io
+- Chain ID: kava-4
+- REST API endpoint: https://kava4.data.kava.io
 - BEP3 deputy's Kava address: kava1r4v2zdhdalfj2ydazallqvrus9fkphmglhn6u6
 - BEP3 deputy's Binance Chain address: bnb1jh7uv2rm6339yue8k4mj9406k3509kr4wt5nxn
 - Binance Chain mainnet REST API endpoint: https://dex.binance.org/
 
+BEP3 deputies
+1. BNB
+  - Kava address: kava1r4v2zdhdalfj2ydazallqvrus9fkphmglhn6u6
+  - Binance Chain address: bnb1jh7uv2rm6339yue8k4mj9406k3509kr4wt5nxn
+2. BUSD
+  - Kava address: kava1hh4x3a4suu5zyaeauvmv7ypf7w9llwlfufjmuu
+  - Binance Chain address:
+3. BTCB
+  - Kava address: kava14qsmvzprqvhwmgql9fr0u3zv9n2qla8zhnm5pc
+  - Binance Chain address:
+4. XRPB
+  - Kava address: kava1qm2u6nyv7kg6awdm46caccgzn5h7mdkde0sue6
+  - Binance Chain address:
+
 ### Testnet
 
-- Chain ID: kava-testnet-8000
-- REST API endpoint: https://kava-testnet-8000.kava.io
-- BEP3 deputy's Kava address: kava1tfvn5t8qwngqd2q427za2mel48pcus3z9u73fl
-- BEP3 deputy's Binance Chain testnet address: tbnb1mdvtph9y0agm4nx7dcl86t7nuvt5mtcul8zld6
+- Chain ID: kava-4-test
+- REST API endpoint: https://kava-4-testnet.kava.io/
 - Binance Chain testnet REST API endpoint: https://testnet-dex.binance.org/
+
+BEP3 deputies
+1. BNB
+  - Kava address: kava1r4v2zdhdalfj2ydazallqvrus9fkphmglhn6u6
+  - Binance Chain address:
 
 ## Client Setup
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kava-labs/javascript-sdk",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-beta.2",
   "description": "Supports interaction with the Kava blockchain via a REST api",
   "main": "index.js",
   "dependencies": {

--- a/src/client/harvest/index.js
+++ b/src/client/harvest/index.js
@@ -50,7 +50,7 @@ class Harvest {
 
   /**
    * Get harvest deposits
-   * @param {Object} args optional arguments {deposit_denom: "btc", deposit_type: "btc-a", owner: "kava1l0xsq2z7gqd7yly0g40y5836g0appumark77ny"}
+   * @param {Object} args optional arguments {deposit_denom: "btc", deposit_type: "lp", owner: "kava1l0xsq2z7gqd7yly0g40y5836g0appumark77ny"}
    * @param {Number} timeout request is attempted every 1000 milliseconds until millisecond timeout is reached
    * @return {Promise}
    */
@@ -63,7 +63,7 @@ class Harvest {
 
   /**
    * Get harvest deposits
-   * @param {Object} args optional arguments {deposit_denom: "btc", deposit_type: "btc-a", owner: "kava1l0xsq2z7gqd7yly0g40y5836g0appumark77ny"}
+   * @param {Object} args optional arguments {deposit_denom: "btc", deposit_type: "lp", owner: "kava1l0xsq2z7gqd7yly0g40y5836g0appumark77ny"}
    * @param {Number} timeout request is attempted every 1000 milliseconds until millisecond timeout is reached
    * @return {Promise}
    */

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -34,6 +34,7 @@ const api = {
   getSwaps: '/bep3/swaps',
   getAssetSupply: 'bep3/supply',
   getAssetSupplies: 'bep3/supplies',
+  getModAccountsCDP: 'cdp/accounts',
   getCDP: 'cdp/cdps/cdp',
   getCDPs: '/cdp/cdps',
   getCDPsByCollateralType: '/cdp/cdps/collateralType',
@@ -506,6 +507,19 @@ class KavaClient {
    */
   async getParamsCDP(timeout = 2000) {
     const res = await tx.getTx(api.getParamsCDP, this.baseURI, timeout);
+    if (res && res.data) {
+      return res.data.result;
+    }
+  }
+
+  /**
+   * Get module accounts associated with the CDP module
+   * @param {Object} args optional arguments {name: "cdp"}
+   * @param {Number} timeout request is attempted every 1000 milliseconds until millisecond timeout is reached
+   * @return {Promise}
+   */
+  async getModAccountsCDP(args = {}, timeout = 2000) {
+    const res = await tx.getTx(api.getModAccountsCDP, this.baseURI, timeout, args);
     if (res && res.data) {
       return res.data.result;
     }
@@ -1063,7 +1077,7 @@ class KavaClient {
 
   /**
    * Issues (mints) coins to a recipient address
-   * @param {String} tokens coins to be issued
+   * @param {Object} tokens coins to be issued as an sdk.Coin
    * @param {String} receiver the recipient of the newly issued coins
    * @param {Number} gas optional gas amount
    * @param {String} sequence optional account sequence
@@ -1121,11 +1135,11 @@ class KavaClient {
    * @param {String} sequence optional account sequence
    * @return {Promise}
    */
-  async unblockAddress(denom, blockedAddress, gas = DEFAULT_GAS, sequence = null) {
+  async unblockAddress(denom, address, gas = DEFAULT_GAS, sequence = null) {
     const msgUnblockAddress = msg.kava.newMsgUnblockAddress(
       this.wallet.address,
       denom,
-      blockedAddress
+      address
     );
     const fee = { amount: [], gas: String(gas) };
     return await this.sendTx([msgUnblockAddress], fee, sequence);


### PR DESCRIPTION
**DON'T MERGE YET.** Once Binance has generated kava-4 deputy addresses, they must be added to the README.

Changes
- Bump version to `3.0.0-beta.2`
- Add CDP module accounts query
- Small clean up edits
- Update README