### PR TITLE
Update MsgClaimHardReward

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kava-labs/javascript-sdk",
-  "version": "4.0.1-beta.1",
+  "version": "4.0.1-beta.2",
   "description": "Supports interaction with the Kava blockchain via a REST api",
   "main": "index.js",
   "dependencies": {

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -876,12 +876,12 @@ class KavaClient {
    * @param {String} sequence optional account sequence
    * @return {Promise}
    */
-  async claimHardLiquidityProviderReward(multiplierName, fee = DEFAULT_FEE, sequence = null) {
-    const msgClaimHardLiquidityProviderReward = msg.kava.newMsgClaimHardLiquidityProviderReward(
+  async claimHardReward(multiplierName, fee = DEFAULT_FEE, sequence = null) {
+    const msgClaimHardReward = msg.kava.newMsgClaimHardReward(
       this.wallet.address,
       multiplierName
     );
-    return await this.sendTx([msgClaimHardLiquidityProviderReward], fee, sequence);
+    return await this.sendTx([msgClaimHardReward], fee, sequence);
   }
 
  /***************************************************

--- a/src/msg/kava/index.js
+++ b/src/msg/kava/index.js
@@ -179,9 +179,9 @@ function newMsgClaimUSDXMintingReward(sender, multiplierName) {
   }
 }
 
-function newMsgClaimHardLiquidityProviderReward(sender, multiplierName) {
+function newMsgClaimHardReward(sender, multiplierName) {
   return {
-    type: 'incentive/MsgClaimHardLiquidityProviderReward',
+    type: 'incentive/MsgClaimHardReward',
     value: {
       sender: sender,
       multiplier_name: multiplierName
@@ -278,7 +278,7 @@ module.exports.kava = {
   newMsgSubmitProposal,
   newMsgVote,
   newMsgClaimUSDXMintingReward,
-  newMsgClaimHardLiquidityProviderReward,
+  newMsgClaimHardReward,
   newMsgIssueTokens,
   newMsgRedeemTokens,
   newMsgBlockAddress,


### PR DESCRIPTION
This PR refactors `MsgClaimHardLiquidityProviderReward` to `MsgClaimHardReward` for compatibility with https://github.com/Kava-Labs/kava/pull/879.

Once approved/merged, I'll publish new npm package version `4.0.1-beta.2`.