### PR TITLE
Adds newMsgTransfer and changes voteType to enum (number)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kava-labs/javascript-sdk",
-  "version": "5.3.2",
+  "version": "6.0.0-beta",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kava-labs/javascript-sdk",
-      "version": "5.3.2",
+      "version": "6.0.0-beta",
       "license": "Apache-2.0",
       "dependencies": {
         "@kava-labs/sig": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kava-labs/javascript-sdk",
-  "version": "5.3.2",
+  "version": "6.0.0-beta",
   "description": "Supports interaction with the Kava blockchain via a REST api",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/msg/cosmos/index.test.ts
+++ b/src/msg/cosmos/index.test.ts
@@ -57,8 +57,8 @@ describe('Cosmos messages', () => {
         amount: '10000000',
       };
       const message = cosmos.newMsgTransfer(
-        'port',
-        'channel',
+        'transfer',
+        'channel-0',
         coin,
         'kava1w66puffhccjck70hw75wu3v92tshw5rmdxp8hb',
         'kava1a22puffhccjck70hw75wu3v92tshw5rmdxp6xz',
@@ -67,8 +67,8 @@ describe('Cosmos messages', () => {
       const expected = {
         type: 'cosmos-sdk/MsgTransfer',
         value: {
-          source_port: 'port',
-          source_channel: 'channel',
+          source_port: 'transfer',
+          source_channel: 'channel-0',
           token: {
             denom: 'ukava',
             amount: '10000000',

--- a/src/msg/cosmos/index.test.ts
+++ b/src/msg/cosmos/index.test.ts
@@ -49,4 +49,38 @@ describe('Cosmos messages', () => {
       });
     });
   });
+
+  describe('newMsgTransfer', () => {
+    it('should generate a well-formed transfer', () => {
+      const coin = {
+        denom: 'ukava',
+        amount: '10000000',
+      };
+      const message = cosmos.newMsgTransfer(
+        'port',
+        'channel',
+        coin,
+        'kava1w66puffhccjck70hw75wu3v92tshw5rmdxp8hb',
+        'kava1a22puffhccjck70hw75wu3v92tshw5rmdxp6xz',
+        23583,
+        1638988347480
+      );
+      const expected = {
+        type: 'cosmos-sdk/MsgTransfer',
+        value: {
+          source_port: 'port',
+          source_channel: 'channel',
+          token: {
+            denom: 'ukava',
+            amount: '10000000',
+          },
+          sender: 'kava1w66puffhccjck70hw75wu3v92tshw5rmdxp8hb',
+          receiver: 'kava1a22puffhccjck70hw75wu3v92tshw5rmdxp6xz',
+          timeoutHeight: 23583,
+          timeoutTimestamp: 1638988347480,
+        },
+      };
+      expect(message).toEqual(expected);
+    });
+  });
 });

--- a/src/msg/cosmos/index.test.ts
+++ b/src/msg/cosmos/index.test.ts
@@ -62,8 +62,7 @@ describe('Cosmos messages', () => {
         coin,
         'kava1w66puffhccjck70hw75wu3v92tshw5rmdxp8hb',
         'kava1a22puffhccjck70hw75wu3v92tshw5rmdxp6xz',
-        23583,
-        1638988347480
+        1638988347480000
       );
       const expected = {
         type: 'cosmos-sdk/MsgTransfer',
@@ -76,8 +75,8 @@ describe('Cosmos messages', () => {
           },
           sender: 'kava1w66puffhccjck70hw75wu3v92tshw5rmdxp8hb',
           receiver: 'kava1a22puffhccjck70hw75wu3v92tshw5rmdxp6xz',
-          timeoutHeight: 23583,
-          timeoutTimestamp: 1638988347480,
+          timeoutHeight: 0,
+          timeoutTimestamp: 1638988347480000,
         },
       };
       expect(message).toEqual(expected);

--- a/src/msg/cosmos/index.ts
+++ b/src/msg/cosmos/index.ts
@@ -29,7 +29,6 @@ function newStdTx<T = unknown>(
   };
 }
 
-// newMsgSend creates a new MsgSend
 function newMsgSend(address: string, to: string, coins: Coin[]) {
   const sendTx = {
     type: 'cosmos-sdk/MsgSend',
@@ -59,6 +58,16 @@ function newMsgVoteGovernance(
   };
 }
 
+/**
+ * Creates an IBC transfer
+ * @param {String} sourcePort the port identifier, we would expect to always be "transfer" * @param {String} sourcePort the port identifier, we would expect to always be "transfer"
+ * @param {String} source_channel the channel identifier
+ * @param {Coin} token
+ * @param {String} sender address of sender on the origin chain
+ * @param {String} receiver address of recipient on the destination chain
+ * @param {Integer} timeoutTimestamp nanoseconds to allow transfer to complete
+
+ */
 function newMsgTransfer(
   sourcePort: string,
   sourceChannel: string,

--- a/src/msg/cosmos/index.ts
+++ b/src/msg/cosmos/index.ts
@@ -59,29 +59,12 @@ function newMsgVoteGovernance(
   };
 }
 
-// func NewMsgTransfer(
-// 	sourcePort, sourceChannel string,
-// 	token sdk.Coin, sender, receiver string,
-// 	timeoutHeight clienttypes.Height, timeoutTimestamp uint64,
-// ) *MsgTransfer {
-// 	return &MsgTransfer{
-// 		SourcePort:       sourcePort,
-// 		SourceChannel:    sourceChannel,
-// 		Token:            token,
-// 		Sender:           sender,
-// 		Receiver:         receiver,
-// 		TimeoutHeight:    timeoutHeight,
-// 		TimeoutTimestamp: timeoutTimestamp,
-// 	}
-// }
-
 function newMsgTransfer(
   sourcePort: string,
   sourceChannel: string,
   token: Coin,
   sender: string,
   receiver: string,
-  timeoutHeight: number,
   timeoutTimestamp: number
 ) {
   return {
@@ -92,7 +75,7 @@ function newMsgTransfer(
       token: token,
       sender: sender,
       receiver: receiver,
-      timeoutHeight: timeoutHeight,
+      timeoutHeight: 0,
       timeoutTimestamp: timeoutTimestamp,
     },
   };

--- a/src/msg/cosmos/index.ts
+++ b/src/msg/cosmos/index.ts
@@ -1,5 +1,5 @@
-import _ from 'lodash';
 import { Coin } from '../../types/Coin';
+import { Message } from '../../types/Message';
 import { VoteType } from '../../types/VoteType';
 
 const FEE_DEFAULT = { amount: [], gas: '300000' };
@@ -12,8 +12,8 @@ const FEE_DEFAULT = { amount: [], gas: '300000' };
  * @param {Object} signatures generated when an address signs a data package, required for tx confirmation
  * @return {Promise}
  */
-function newStdTx(
-  msgs: any[],
+function newStdTx<T = unknown>(
+  msgs: Message<T>[],
   fee = FEE_DEFAULT,
   memo = '',
   signatures = null
@@ -59,8 +59,48 @@ function newMsgVoteGovernance(
   };
 }
 
+// func NewMsgTransfer(
+// 	sourcePort, sourceChannel string,
+// 	token sdk.Coin, sender, receiver string,
+// 	timeoutHeight clienttypes.Height, timeoutTimestamp uint64,
+// ) *MsgTransfer {
+// 	return &MsgTransfer{
+// 		SourcePort:       sourcePort,
+// 		SourceChannel:    sourceChannel,
+// 		Token:            token,
+// 		Sender:           sender,
+// 		Receiver:         receiver,
+// 		TimeoutHeight:    timeoutHeight,
+// 		TimeoutTimestamp: timeoutTimestamp,
+// 	}
+// }
+
+function newMsgTransfer(
+  sourcePort: string,
+  sourceChannel: string,
+  token: Coin,
+  sender: string,
+  receiver: string,
+  timeoutHeight: number,
+  timeoutTimestamp: number
+) {
+  return {
+    type: 'cosmos-sdk/MsgTransfer',
+    value: {
+      source_port: sourcePort,
+      source_channel: sourceChannel,
+      token: token,
+      sender: sender,
+      receiver: receiver,
+      timeoutHeight: timeoutHeight,
+      timeoutTimestamp: timeoutTimestamp,
+    },
+  };
+}
+
 export const cosmos = {
   newStdTx,
   newMsgSend,
   newMsgVoteGovernance,
+  newMsgTransfer,
 };

--- a/src/types/Message.ts
+++ b/src/types/Message.ts
@@ -1,0 +1,4 @@
+export type Message<T> = {
+  type: string;
+  value: T;
+};

--- a/src/types/VoteType.ts
+++ b/src/types/VoteType.ts
@@ -1,1 +1,5 @@
-export type VoteType = 'Yes' | 'No' | 'Abstain';
+export enum VoteType {
+  YES = 1,
+  ABSTAIN = 2,
+  NO = 3,
+}


### PR DESCRIPTION
⚡ [Asana Task](https://app.asana.com/0/1189045082777889/1201474845033045/f)

What Changes
---
* Adds a `Message` type
* Changes VoteType to enum (with explicit number assignments) [See Cosmos VoteOption](https://github.com/allinbits/cosmos-sdk/blob/69ab58ed2e7f50f4a5d2726454a1c467f17f4e09/x/gov/types/gov.pb.go#L59-L64)
* Adds newMsgTransfer and test

Questions
---
* Since we plan on setting expiry with a timestamp, rather than a block height, should our SDK be "opinionated" about that? E.g. should we only accept a timestamp, and always set the block height to undefined (or null)?
* Do we have opinions about versioning this library? This is a breaking change, so bumping the major version seems like the obvious way forward, but it's a little ugly that it's out of sync with the thing it's versioning (which is our Kava chain)—I suppose we could go to v9? (since this upgrade will be the launch of Kava 9) **I think I like this**