### PR TITLE
Proposed Change to Naming Convention

### DIFF
--- a/example/swap.ts
+++ b/example/swap.ts
@@ -43,7 +43,7 @@ var main = async () => {
   const slippage = '0.010000000000000000';
   const deadline = kavaUtils.calculateUnixTime(30);
 
-  const swapExactForRes = await kavaClient.swap.newMsgSwapExactForTokens(
+  const swapExactForRes = await kavaClient.swap.SwapExactForTokens(
     exactTokenA,
     tokenB,
     slippage,
@@ -61,7 +61,7 @@ var main = async () => {
   const slippage = '0.010000000000000000';
   const deadline = kavaUtils.calculateUnixTime(30);
 
-  const swapForExactRes = await kavaClient.swap.newMsgSwapForExactTokens(
+  const swapForExactRes = await kavaClient.swap.SwapForExactTokens(
     tokenA,
     exactTokenB,
     slippage,

--- a/src/client/hard/index.ts
+++ b/src/client/hard/index.ts
@@ -140,7 +140,7 @@ export class Hard {
     if (!this.kavaClient.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgDeposit = msg.hard.newMsgDeposit(
+    const msgDeposit = msg.hard.Deposit(
       this.kavaClient.wallet.address,
       amount
     );
@@ -159,7 +159,7 @@ export class Hard {
     if (!this.kavaClient.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgWithdraw = msg.hard.newMsgWithdraw(
+    const msgWithdraw = msg.hard.Withdraw(
       this.kavaClient.wallet.address,
       amount
     );
@@ -178,7 +178,7 @@ export class Hard {
     if (!this.kavaClient.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgBorrow = msg.hard.newMsgBorrow(
+    const msgBorrow = msg.hard.Borrow(
       this.kavaClient.wallet.address,
       amount
     );
@@ -197,7 +197,7 @@ export class Hard {
     if (!this.kavaClient.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgRepay = msg.hard.newMsgRepay(
+    const msgRepay = msg.hard.Repay(
       this.kavaClient.wallet.address,
       this.kavaClient.wallet.address,
       amount
@@ -217,7 +217,7 @@ export class Hard {
     if (!this.kavaClient.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgLiquidate = msg.hard.newMsgLiquidate(
+    const msgLiquidate = msg.hard.Liquidate(
       this.kavaClient.wallet.address,
       borrower
     );

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -195,7 +195,7 @@ export class KavaClient {
    * @return {Promise}
    */
   async sendTx(msgs: any[], fee: any, sequence: string | null) {
-    const rawTx = msg.cosmos.newStdTx(msgs, fee);
+    const rawTx = msg.cosmos. StdTx(msgs, fee);
     const signInfo = await this.prepareSignInfo(sequence);
     const signedTx = tx.signTx(rawTx, signInfo, this.wallet);
     return await tx.broadcastTx(signedTx, this.baseURI, this.broadcastMode);
@@ -391,7 +391,7 @@ export class KavaClient {
     if (!this.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgSend = msg.cosmos.newMsgSend(
+    const msgSend = msg.cosmos.Send(
       this.wallet.address,
       recipient,
       coins
@@ -487,7 +487,7 @@ export class KavaClient {
     if (!this.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgPostPrice = msg.kava.newMsgPostPrice(
+    const msgPostPrice = msg.kava.PostPrice(
       this.wallet.address,
       marketID,
       price,
@@ -555,7 +555,7 @@ export class KavaClient {
     if (!this.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgPlaceBid = msg.kava.newMsgPlaceBid(
+    const msgPlaceBid = msg.kava.PlaceBid(
       auctionID,
       this.wallet.address,
       amount
@@ -669,7 +669,7 @@ export class KavaClient {
     if (!this.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgCreateCDP = msg.kava.newMsgCreateCDP(
+    const msgCreateCDP = msg.kava.CreateCDP(
       this.wallet.address,
       principal,
       collateral,
@@ -697,7 +697,7 @@ export class KavaClient {
     if (!this.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgDeposit = msg.kava.newMsgDeposit(
+    const msgDeposit = msg.kava.Deposit(
       owner,
       this.wallet.address,
       collateral,
@@ -725,7 +725,7 @@ export class KavaClient {
     if (!this.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgWithdraw = msg.kava.newMsgWithdraw(
+    const msgWithdraw = msg.kava.Withdraw(
       owner,
       this.wallet.address,
       collateral,
@@ -751,7 +751,7 @@ export class KavaClient {
     if (!this.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgDrawDebt = msg.kava.newMsgDrawDebt(
+    const msgDrawDebt = msg.kava.DrawDebt(
       this.wallet.address,
       collateralType,
       principal
@@ -776,7 +776,7 @@ export class KavaClient {
     if (!this.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgRepayDebt = msg.kava.newMsgRepayDebt(
+    const msgRepayDebt = msg.kava.RepayDebt(
       this.wallet.address,
       collateralType,
       payment
@@ -801,7 +801,7 @@ export class KavaClient {
     if (!this.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgLiquidate = msg.kava.newMsgLiquidate(
+    const msgLiquidate = msg.kava.Liquidate(
       this.wallet.address,
       borrower,
       collateralType
@@ -904,7 +904,7 @@ export class KavaClient {
     if (!this.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgCreateAtomicSwap = msg.kava.newMsgCreateAtomicSwap(
+    const msgCreateAtomicSwap = msg.kava.CreateAtomicSwap(
       this.wallet.address,
       recipient,
       recipientOtherChain,
@@ -934,7 +934,7 @@ export class KavaClient {
     if (!this.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgClaimAtomicSwap = msg.kava.newMsgClaimAtomicSwap(
+    const msgClaimAtomicSwap = msg.kava.ClaimAtomicSwap(
       this.wallet.address,
       swapID.toUpperCase(),
       randomNumber.toUpperCase()
@@ -953,7 +953,7 @@ export class KavaClient {
     if (!this.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgRefundAtomicSwap = msg.kava.newMsgRefundAtomicSwap(
+    const msgRefundAtomicSwap = msg.kava.RefundAtomicSwap(
       this.wallet.address,
       swapID.toUpperCase()
     );
@@ -1004,7 +1004,7 @@ export class KavaClient {
     if (!this.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgClaimUSDXMintingReward = msg.kava.newMsgClaimUSDXMintingReward(
+    const msgClaimUSDXMintingReward = msg.kava.ClaimUSDXMintingReward(
       this.wallet.address,
       multiplierName
     );
@@ -1028,7 +1028,7 @@ export class KavaClient {
     if (!this.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgClaimUSDXMintingRewardVVesting = msg.kava.newMsgClaimUSDXMintingRewardVVesting(
+    const msgClaimUSDXMintingRewardVVesting = msg.kava.ClaimUSDXMintingRewardVVesting(
       this.wallet.address,
       receiver,
       multiplierName
@@ -1057,7 +1057,7 @@ export class KavaClient {
     if (!this.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgClaimHardReward = msg.kava.newMsgClaimHardReward(
+    const msgClaimHardReward = msg.kava.ClaimHardReward(
       this.wallet.address,
       denomsToClaim
     );
@@ -1083,7 +1083,7 @@ export class KavaClient {
     if (!this.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgClaimHardRewardVVesting = msg.kava.newMsgClaimHardRewardVVesting(
+    const msgClaimHardRewardVVesting = msg.kava.ClaimHardRewardVVesting(
       this.wallet.address,
       receiver,
       denomsToClaim
@@ -1108,7 +1108,7 @@ export class KavaClient {
     if (!this.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgClaimDelegatorReward = msg.kava.newMsgClaimDelegatorReward(
+    const msgClaimDelegatorReward = msg.kava.ClaimDelegatorReward(
       this.wallet.address,
       denomsToClaim
     );
@@ -1134,7 +1134,7 @@ export class KavaClient {
     if (!this.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgClaimDelegatorRewardVVesting = msg.kava.newMsgClaimDelegatorRewardVVesting(
+    const msgClaimDelegatorRewardVVesting = msg.kava.ClaimDelegatorRewardVVesting(
       this.wallet.address,
       receiver,
       denomsToClaim
@@ -1159,7 +1159,7 @@ export class KavaClient {
     if (!this.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgClaimSwapReward = msg.kava.newMsgClaimSwapReward(
+    const msgClaimSwapReward = msg.kava.ClaimSwapReward(
       this.wallet.address,
       denomsToClaim
     );
@@ -1185,7 +1185,7 @@ export class KavaClient {
     if (!this.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgClaimSwapRewardVVesting = msg.kava.newMsgClaimSwapRewardVVesting(
+    const msgClaimSwapRewardVVesting = msg.kava.ClaimSwapRewardVVesting(
       this.wallet.address,
       receiver,
       denomsToClaim
@@ -1321,7 +1321,7 @@ export class KavaClient {
     if (!this.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgSubmitProposal = msg.kava.newMsgSubmitProposal(
+    const msgSubmitProposal = msg.kava.SubmitProposal(
       proposal,
       this.wallet.address,
       committeeID
@@ -1345,7 +1345,7 @@ export class KavaClient {
     if (!this.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgVote = msg.kava.newMsgVote(
+    const msgVote = msg.kava.Vote(
       proposalID,
       this.wallet.address,
       voteType
@@ -1385,7 +1385,7 @@ export class KavaClient {
     if (!this.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgIssueTokens = msg.kava.newMsgIssueTokens(
+    const msgIssueTokens = msg.kava.IssueTokens(
       this.wallet.address,
       tokens,
       receiver
@@ -1404,7 +1404,7 @@ export class KavaClient {
     if (!this.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgRedeemTokens = msg.kava.newMsgRedeemTokens(
+    const msgRedeemTokens = msg.kava.RedeemTokens(
       this.wallet.address,
       tokens
     );
@@ -1428,7 +1428,7 @@ export class KavaClient {
     if (!this.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgBlockAddress = msg.kava.newMsgBlockAddress(
+    const msgBlockAddress = msg.kava.BlockAddress(
       this.wallet.address,
       denom,
       blockedAddress
@@ -1453,7 +1453,7 @@ export class KavaClient {
     if (!this.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgUnblockAddress = msg.kava.newMsgUnblockAddress(
+    const msgUnblockAddress = msg.kava.UnblockAddress(
       this.wallet.address,
       denom,
       blockedAddress
@@ -1478,7 +1478,7 @@ export class KavaClient {
     if (!this.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgSetPauseStatus = msg.kava.newMsgSetPauseStatus(
+    const msgSetPauseStatus = msg.kava.SetPauseStatus(
       this.wallet.address,
       denom,
       status

--- a/src/client/swap/index.ts
+++ b/src/client/swap/index.ts
@@ -111,7 +111,7 @@ class Swap {
     if (!this.kavaClient.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgDeposit = msg.swap.newMsgDeposit(
+    const msgDeposit = msg.swap.Deposit(
       this.kavaClient.wallet.address,
       tokenA,
       tokenB,
@@ -144,7 +144,7 @@ class Swap {
     if (!this.kavaClient.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgWithdraw = msg.swap.newMsgWithdraw(
+    const msgWithdraw = msg.swap.Withdraw(
       this.kavaClient.wallet.address,
       shares,
       minTokenA,
@@ -176,7 +176,7 @@ class Swap {
     if (!this.kavaClient.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgSwapExactForTokens = msg.swap.newMsgSwapExactForTokens(
+    const msgSwapExactForTokens = msg.swap.SwapExactForTokens(
       this.kavaClient.wallet.address,
       exactTokenA,
       tokenB,
@@ -208,7 +208,7 @@ class Swap {
     if (!this.kavaClient.wallet) {
       throw Error('Wallet has not yet been initialized');
     }
-    const msgSwapForExactTokens = msg.swap.newMsgSwapForExactTokens(
+    const msgSwapForExactTokens = msg.swap.SwapForExactTokens(
       this.kavaClient.wallet.address,
       tokenA,
       exactTokenB,

--- a/src/msg/cosmos/index.test.ts
+++ b/src/msg/cosmos/index.test.ts
@@ -1,7 +1,7 @@
 import { cosmos } from '.';
 
 describe('Cosmos messages', () => {
-  describe('newMsgSend', () => {
+  describe('Send', () => {
     it('should sort the coins passed in by denom', () => {
       const coins = [
         {
@@ -21,7 +21,7 @@ describe('Cosmos messages', () => {
           amount: '20000000',
         },
       ];
-      const message = cosmos.newMsgSend('kavafrom', 'kavato', coins);
+      const message = cosmos.Send('kavafrom', 'kavato', coins);
       expect(message).toStrictEqual({
         type: 'cosmos-sdk/MsgSend',
         value: {
@@ -50,13 +50,13 @@ describe('Cosmos messages', () => {
     });
   });
 
-  describe('newMsgTransfer', () => {
+  describe('Transfer', () => {
     it('should generate a well-formed transfer', () => {
       const coin = {
         denom: 'ukava',
         amount: '10000000',
       };
-      const message = cosmos.newMsgTransfer(
+      const message = cosmos.Transfer(
         'transfer',
         'channel-0',
         coin,

--- a/src/msg/cosmos/index.ts
+++ b/src/msg/cosmos/index.ts
@@ -12,7 +12,7 @@ const FEE_DEFAULT = { amount: [], gas: '300000' };
  * @param {Object} signatures generated when an address signs a data package, required for tx confirmation
  * @return {Promise}
  */
-function newStdTx<T = unknown>(
+function StdTx<T = unknown>(
   msgs: Message<T>[],
   fee = FEE_DEFAULT,
   memo = '',
@@ -29,7 +29,7 @@ function newStdTx<T = unknown>(
   };
 }
 
-function newMsgSend(address: string, to: string, coins: Coin[]) {
+function Send(address: string, to: string, coins: Coin[]) {
   const sendTx = {
     type: 'cosmos-sdk/MsgSend',
     value: {
@@ -43,7 +43,7 @@ function newMsgSend(address: string, to: string, coins: Coin[]) {
   return sendTx;
 }
 
-function newMsgVoteGovernance(
+function VoteGovernance(
   proposalID: string,
   voter: string,
   voteType: VoteType
@@ -68,7 +68,7 @@ function newMsgVoteGovernance(
  * @param {Integer} timeoutTimestamp nanoseconds to allow transfer to complete
 
  */
-function newMsgTransfer(
+function Transfer(
   sourcePort: string,
   sourceChannel: string,
   token: Coin,
@@ -91,8 +91,8 @@ function newMsgTransfer(
 }
 
 export const cosmos = {
-  newStdTx,
-  newMsgSend,
-  newMsgVoteGovernance,
-  newMsgTransfer,
+  StdTx,
+  Send,
+  VoteGovernance,
+  Transfer,
 };

--- a/src/msg/hard/index.ts
+++ b/src/msg/hard/index.ts
@@ -1,6 +1,6 @@
 import { Coin } from '../../types/Coin';
 
-function newMsgDeposit(depositor: string, amount: Coin[]) {
+function Deposit(depositor: string, amount: Coin[]) {
   return {
     type: 'hard/MsgDeposit',
     value: {
@@ -10,7 +10,7 @@ function newMsgDeposit(depositor: string, amount: Coin[]) {
   };
 }
 
-function newMsgWithdraw(depositor: string, amount: Coin[]) {
+function Withdraw(depositor: string, amount: Coin[]) {
   return {
     type: 'hard/MsgWithdraw',
     value: {
@@ -20,7 +20,7 @@ function newMsgWithdraw(depositor: string, amount: Coin[]) {
   };
 }
 
-function newMsgBorrow(borrower: string, amount: Coin[]) {
+function Borrow(borrower: string, amount: Coin[]) {
   return {
     type: 'hard/MsgBorrow',
     value: {
@@ -30,7 +30,7 @@ function newMsgBorrow(borrower: string, amount: Coin[]) {
   };
 }
 
-function newMsgRepay(sender: string, owner: string, amount: Coin[]) {
+function Repay(sender: string, owner: string, amount: Coin[]) {
   return {
     type: 'hard/MsgRepay',
     value: {
@@ -41,7 +41,7 @@ function newMsgRepay(sender: string, owner: string, amount: Coin[]) {
   };
 }
 
-function newMsgLiquidate(keeper: string, borrower: string) {
+function Liquidate(keeper: string, borrower: string) {
   return {
     type: 'hard/MsgLiquidate',
     value: {
@@ -52,9 +52,9 @@ function newMsgLiquidate(keeper: string, borrower: string) {
 }
 
 export const hard = {
-  newMsgDeposit,
-  newMsgWithdraw,
-  newMsgBorrow,
-  newMsgRepay,
-  newMsgLiquidate,
+  Deposit,
+  Withdraw,
+  Borrow,
+  Repay,
+  Liquidate,
 };

--- a/src/msg/kava/index.ts
+++ b/src/msg/kava/index.ts
@@ -6,7 +6,7 @@ import { VoteType } from '../../types/VoteType';
  *                   Auction
  ***************************************************/
 
-function newMsgPlaceBid(auctionID: string, bidder: string, amount: Coin) {
+function PlaceBid(auctionID: string, bidder: string, amount: Coin) {
   return {
     type: 'auction/MsgPlaceBid',
     value: {
@@ -21,8 +21,8 @@ function newMsgPlaceBid(auctionID: string, bidder: string, amount: Coin) {
  *                     BEP3
  ***************************************************/
 
-// newMsgCreateAtomicSwap creates a new MsgCreateAtomicSwap
-function newMsgCreateAtomicSwap(
+// CreateAtomicSwap creates a new MsgCreateAtomicSwap
+function CreateAtomicSwap(
   sender: string,
   recipient: string,
   recipientOtherChain: string,
@@ -47,8 +47,8 @@ function newMsgCreateAtomicSwap(
   };
 }
 
-// newMsgClaimAtomicSwap creates a new MsgClaimAtomicSwap
-function newMsgClaimAtomicSwap(
+// ClaimAtomicSwap creates a new MsgClaimAtomicSwap
+function ClaimAtomicSwap(
   sender: string,
   swapID: string,
   randomNumber: string
@@ -63,8 +63,8 @@ function newMsgClaimAtomicSwap(
   };
 }
 
-// newMsgRefundAtomicSwap creates a new MsgRefundAtomicSwap
-function newMsgRefundAtomicSwap(sender: string, swapID: string) {
+// RefundAtomicSwap creates a new MsgRefundAtomicSwap
+function RefundAtomicSwap(sender: string, swapID: string) {
   return {
     type: 'bep3/MsgRefundAtomicSwap',
     value: {
@@ -78,7 +78,7 @@ function newMsgRefundAtomicSwap(sender: string, swapID: string) {
  *                       CDP
  ***************************************************/
 
-function newMsgCreateCDP(
+function CreateCDP(
   sender: string,
   principal: Coin,
   collateral: Coin,
@@ -95,7 +95,7 @@ function newMsgCreateCDP(
   };
 }
 
-function newMsgDeposit(
+function Deposit(
   owner: string,
   depositor: string,
   collateral: Coin,
@@ -112,7 +112,7 @@ function newMsgDeposit(
   };
 }
 
-function newMsgWithdraw(
+function Withdraw(
   owner: string,
   depositor: string,
   collateral: Coin,
@@ -129,7 +129,7 @@ function newMsgWithdraw(
   };
 }
 
-function newMsgDrawDebt(
+function DrawDebt(
   sender: string,
   collateralType: string,
   principal: Coin
@@ -144,7 +144,7 @@ function newMsgDrawDebt(
   };
 }
 
-function newMsgRepayDebt(
+function RepayDebt(
   sender: string,
   collateralType: string,
   payment: Coin
@@ -159,7 +159,7 @@ function newMsgRepayDebt(
   };
 }
 
-function newMsgLiquidate(
+function Liquidate(
   keeper: string,
   borrower: string,
   collateralType: string
@@ -178,7 +178,7 @@ function newMsgLiquidate(
  *                   Committee
  ***************************************************/
 
-function newMsgSubmitProposal(
+function SubmitProposal(
   proposal: string,
   proposer: string,
   committeeID: string
@@ -193,7 +193,7 @@ function newMsgSubmitProposal(
   };
 }
 
-function newMsgVote(proposalID: string, voter: string, voteType: VoteType) {
+function Vote(proposalID: string, voter: string, voteType: VoteType) {
   return {
     type: 'kava/MsgVote',
     value: {
@@ -208,7 +208,7 @@ function newMsgVote(proposalID: string, voter: string, voteType: VoteType) {
  *                   Incentive
  ***************************************************/
 
-function newMsgClaimUSDXMintingReward(sender: string, multiplierName: string) {
+function ClaimUSDXMintingReward(sender: string, multiplierName: string) {
   return {
     type: 'incentive/MsgClaimUSDXMintingReward',
     value: {
@@ -218,7 +218,7 @@ function newMsgClaimUSDXMintingReward(sender: string, multiplierName: string) {
   };
 }
 
-function newMsgClaimUSDXMintingRewardVVesting(
+function ClaimUSDXMintingRewardVVesting(
   sender: string,
   receiver: string,
   multiplierName: string
@@ -233,7 +233,7 @@ function newMsgClaimUSDXMintingRewardVVesting(
   };
 }
 
-function newMsgClaimHardReward(sender: string, denomsToClaim: any[]) {
+function ClaimHardReward(sender: string, denomsToClaim: any[]) {
   return {
     type: 'incentive/MsgClaimHardReward',
     value: {
@@ -243,7 +243,7 @@ function newMsgClaimHardReward(sender: string, denomsToClaim: any[]) {
   };
 }
 
-function newMsgClaimHardRewardVVesting(
+function ClaimHardRewardVVesting(
   sender: string,
   receiver: string,
   denomsToClaim: DenomToClaim[]
@@ -258,7 +258,7 @@ function newMsgClaimHardRewardVVesting(
   };
 }
 
-function newMsgClaimDelegatorReward(
+function ClaimDelegatorReward(
   sender: string,
   denomsToClaim: DenomToClaim[]
 ) {
@@ -271,7 +271,7 @@ function newMsgClaimDelegatorReward(
   };
 }
 
-function newMsgClaimDelegatorRewardVVesting(
+function ClaimDelegatorRewardVVesting(
   sender: string,
   receiver: string,
   denomsToClaim: any[]
@@ -286,7 +286,7 @@ function newMsgClaimDelegatorRewardVVesting(
   };
 }
 
-function newMsgClaimSwapReward(sender: string, denomsToClaim: DenomToClaim[]) {
+function ClaimSwapReward(sender: string, denomsToClaim: DenomToClaim[]) {
   return {
     type: 'incentive/MsgClaimSwapReward',
     value: {
@@ -296,7 +296,7 @@ function newMsgClaimSwapReward(sender: string, denomsToClaim: DenomToClaim[]) {
   };
 }
 
-function newMsgClaimSwapRewardVVesting(
+function ClaimSwapRewardVVesting(
   sender: string,
   receiver: string,
   denomsToClaim: DenomToClaim[]
@@ -315,7 +315,7 @@ function newMsgClaimSwapRewardVVesting(
  *                   Issuance
  ***************************************************/
 
-function newMsgIssueTokens(sender: string, tokens: any[], receiver: string) {
+function IssueTokens(sender: string, tokens: any[], receiver: string) {
   return {
     type: 'issuance/MsgIssueTokens',
     value: {
@@ -326,7 +326,7 @@ function newMsgIssueTokens(sender: string, tokens: any[], receiver: string) {
   };
 }
 
-function newMsgRedeemTokens(sender: string, tokens: any[]) {
+function RedeemTokens(sender: string, tokens: any[]) {
   return {
     type: 'issuance/MsgRedeemTokens',
     value: {
@@ -336,7 +336,7 @@ function newMsgRedeemTokens(sender: string, tokens: any[]) {
   };
 }
 
-function newMsgBlockAddress(
+function BlockAddress(
   sender: string,
   denom: string,
   blockedAddress: string
@@ -351,7 +351,7 @@ function newMsgBlockAddress(
   };
 }
 
-function newMsgUnblockAddress(sender: string, denom: string, address: string) {
+function UnblockAddress(sender: string, denom: string, address: string) {
   return {
     type: 'issuance/MsgUnblockAddress',
     value: {
@@ -362,7 +362,7 @@ function newMsgUnblockAddress(sender: string, denom: string, address: string) {
   };
 }
 
-function newMsgSetPauseStatus(sender: string, denom: string, status: string) {
+function SetPauseStatus(sender: string, denom: string, status: string) {
   return {
     type: 'issuance/MsgChangePauseStatus',
     value: {
@@ -377,7 +377,7 @@ function newMsgSetPauseStatus(sender: string, denom: string, status: string) {
  *                   Pricefeed
  ***************************************************/
 
-function newMsgPostPrice(
+function PostPrice(
   from: string,
   marketID: string,
   price: string,
@@ -395,30 +395,30 @@ function newMsgPostPrice(
 }
 
 export const kava = {
-  newMsgPlaceBid,
-  newMsgCreateAtomicSwap,
-  newMsgClaimAtomicSwap,
-  newMsgRefundAtomicSwap,
-  newMsgCreateCDP,
-  newMsgDeposit,
-  newMsgWithdraw,
-  newMsgDrawDebt,
-  newMsgRepayDebt,
-  newMsgLiquidate,
-  newMsgSubmitProposal,
-  newMsgVote,
-  newMsgClaimUSDXMintingReward,
-  newMsgClaimUSDXMintingRewardVVesting,
-  newMsgClaimHardReward,
-  newMsgClaimHardRewardVVesting,
-  newMsgClaimDelegatorReward,
-  newMsgClaimDelegatorRewardVVesting,
-  newMsgClaimSwapReward,
-  newMsgClaimSwapRewardVVesting,
-  newMsgIssueTokens,
-  newMsgRedeemTokens,
-  newMsgBlockAddress,
-  newMsgUnblockAddress,
-  newMsgSetPauseStatus,
-  newMsgPostPrice,
+  PlaceBid,
+  CreateAtomicSwap,
+  ClaimAtomicSwap,
+  RefundAtomicSwap,
+  CreateCDP,
+  Deposit,
+  Withdraw,
+  DrawDebt,
+  RepayDebt,
+  Liquidate,
+  SubmitProposal,
+  Vote,
+  ClaimUSDXMintingReward,
+  ClaimUSDXMintingRewardVVesting,
+  ClaimHardReward,
+  ClaimHardRewardVVesting,
+  ClaimDelegatorReward,
+  ClaimDelegatorRewardVVesting,
+  ClaimSwapReward,
+  ClaimSwapRewardVVesting,
+  IssueTokens,
+  RedeemTokens,
+  BlockAddress,
+  UnblockAddress,
+  SetPauseStatus,
+  PostPrice,
 };

--- a/src/msg/swap/index.ts
+++ b/src/msg/swap/index.ts
@@ -1,6 +1,6 @@
 import { Coin } from '../../types/Coin';
 
-function newMsgDeposit(
+function Deposit(
   depositor: string,
   tokenA: Coin,
   tokenB: Coin,
@@ -19,7 +19,7 @@ function newMsgDeposit(
   };
 }
 
-function newMsgWithdraw(
+function Withdraw(
   from: string,
   shares: any,
   minTokenA: Coin,
@@ -38,7 +38,7 @@ function newMsgWithdraw(
   };
 }
 
-function newMsgSwapExactForTokens(
+function SwapExactForTokens(
   requester: string,
   exactTokenA: Coin,
   tokenB: Coin,
@@ -57,7 +57,7 @@ function newMsgSwapExactForTokens(
   };
 }
 
-function newMsgSwapForExactTokens(
+function SwapForExactTokens(
   requester: string,
   tokenA: Coin,
   exactTokenB: Coin,
@@ -77,8 +77,8 @@ function newMsgSwapForExactTokens(
 }
 
 export const swap = {
-  newMsgDeposit,
-  newMsgWithdraw,
-  newMsgSwapExactForTokens,
-  newMsgSwapForExactTokens,
+  Deposit,
+  Withdraw,
+  SwapExactForTokens,
+  SwapForExactTokens,
 };


### PR DESCRIPTION
It seems like there's a lot of unnecessary prefixing. `newMsg` for seems redundant in that both 'new' is implied and 'msg' is prefixed by the module export (`Kava.msg.hard.newMsgWithdraw` for example).

This would allows us to instead say (`Kava.msg.hard.Withdraw`)

I think I like this better? But maybe it isn't worth it?